### PR TITLE
fix: use version table in strat loader

### DIFF
--- a/packages/balancer-strategies/README.md
+++ b/packages/balancer-strategies/README.md
@@ -1,18 +1,24 @@
 # balancer-strategies
 
-Pluggable load balancing strategy interface. Strategies are compiled as shared libraries and can be hot-swapped at runtime via `dlopen`.
+Pluggable load balancing strategy interface. Strategies are shared libraries hot-swapped at runtime via `dlopen`.
 
-## Build Strategy
+## Available Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `libteststrategy.so` | Round-robin (cycles through servers) |
+| `libweightedstrategy.so` | Weighted (distributes by server weight) |
+
+## Build
 
 ```bash
-g++ -shared -fPIC -o build/libteststrategy.so strategies/test-strategy-impl.cpp -I include
+bazel build //packages/balancer-strategies:libweightedstrategy.so
 ```
 
-## Build & Run Tests
+## Test
 
 ```bash
-g++ -o build/test_main test/main.cpp -I include -ldl
-./build/test_main
+bazel test //packages/balancer-strategies:strategy_test
 ```
 
 ## Implement a Strategy

--- a/packages/version-table/include/table.hpp
+++ b/packages/version-table/include/table.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 
-// Single-process hot-swap slot with reference counting.
-// Use in_flight to track active users before unloading.
+// single process hot-swap slot with reference counting
+// uses in_flight to track active users before unloading
 template <typename T> struct Slot {
 	T *data = nullptr;
 	void *dl_handle = nullptr;
@@ -13,19 +14,20 @@ template <typename T> struct Slot {
 	void acquire()
 	{
 		in_flight.fetch_add(1, std::memory_order_acq_rel);
-	}
+	} // bump refcount
 	void release()
 	{
 		in_flight.fetch_sub(1, std::memory_order_release);
-	}
+	} // drop refcount
 	bool idle() const
 	{
-		return in_flight.load(std::memory_order_acquire) == 0;
+		return in_flight.load(std::memory_order_acquire) ==
+		       0; // check if drainable
 	}
 };
 
-// Two-slot table for hot-swapping: one active, one for loading new version.
-// Pattern: load into inactive slot, swap active_index, wait for old to drain.
+// two slot table for hot swapping: one active, one for loading new version
+// use: load into inactive slot, swap active_index, wait for old to drain
 template <typename T, size_t N = 2> struct HotSwapTable {
 	Slot<T> slots[N];
 	std::atomic<size_t> active_index{0};
@@ -46,9 +48,9 @@ template <typename T, size_t N = 2> struct HotSwapTable {
 	}
 };
 
-// Cross-process shared memory slot (for future use).
-// Stores path instead of pointers since pointers aren't shareable across
-// processes.
+// cross-process shared memory slot (for future)
+// stores path instead of pointers since pointers aren't shareable across
+// processes
 struct SharedSlot {
 	std::atomic<uint64_t> version;
 	std::atomic<int32_t> refcount;

--- a/packages/version-table/include/table.hpp
+++ b/packages/version-table/include/table.hpp
@@ -1,30 +1,62 @@
-#include <atomic>
-
 #pragma once
 
-struct SharedSlot {
-	std::atomic<uint64_t> version; // monotonic version counter
-	std::atomic<int32_t> refcount; // how many processes are mid-call
-	std::atomic<bool> active;      // still loadable or marked for cleanup
-	char dll_path[256];	       // or symbol name, whatever you need
+#include <atomic>
+#include <cstdint>
+
+// Single-process hot-swap slot with reference counting.
+// Use in_flight to track active users before unloading.
+template <typename T> struct Slot {
+	T *data = nullptr;
+	void *dl_handle = nullptr;
+	std::atomic<int32_t> in_flight{0};
+
+	void acquire()
+	{
+		in_flight.fetch_add(1, std::memory_order_acq_rel);
+	}
+	void release()
+	{
+		in_flight.fetch_sub(1, std::memory_order_release);
+	}
+	bool idle() const
+	{
+		return in_flight.load(std::memory_order_acquire) == 0;
+	}
 };
 
-struct VersionTable {
-	std::atomic<uint32_t> latest_index; // points to the latest slot
+// Two-slot table for hot-swapping: one active, one for loading new version.
+// Pattern: load into inactive slot, swap active_index, wait for old to drain.
+template <typename T, size_t N = 2> struct HotSwapTable {
+	Slot<T> slots[N];
+	std::atomic<size_t> active_index{0};
+
+	Slot<T> &active()
+	{
+		return slots[active_index.load(std::memory_order_acquire)];
+	}
+	Slot<T> &inactive()
+	{
+		return slots[active_index.load(std::memory_order_acquire) ^ 1];
+	}
+
+	void swap()
+	{
+		size_t old = active_index.load(std::memory_order_acquire);
+		active_index.store(old ^ 1, std::memory_order_release);
+	}
+};
+
+// Cross-process shared memory slot (for future use).
+// Stores path instead of pointers since pointers aren't shareable across
+// processes.
+struct SharedSlot {
+	std::atomic<uint64_t> version;
+	std::atomic<int32_t> refcount;
+	std::atomic<bool> active;
+	char dll_path[256];
+};
+
+struct SharedVersionTable {
+	std::atomic<uint32_t> latest_index;
 	SharedSlot slots[8];
 };
-
-// The read path for any process:
-
-// Atomic load current_index
-// Bump refcount on that slot
-// Look up the function pointer locally (each process keeps its own dlopen
-// handle / GetProcAddress result cached per version) Call the function
-// Decrement refcount
-
-// The write path (whoever publishes a new DLL version):
-
-// Find a free slot (refcount 0, not current)
-// Fill in the dll path / version
-// Atomic store to current_index
-// Mark old slots with refcount 0 as reclaimable

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -19,6 +19,7 @@ cc_binary(
     deps = [
         "//packages/balancer-strategies:strategy",
         "//packages/config",
+        "//packages/version-table",
         "@dpdk",
     ],
 )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,12 +155,13 @@ int main(int argc, char *argv[])
 		rte_exit(EXIT_FAILURE, "Cannot init port %" PRIu16 "\n",
 			 portid);
 
-	if (!load_into_slot(&slots[0], "./strategies/libstrategy.so")) {
+	if (!load_into_slot(&strategy_table.slots[0],
+			    "./strategies/libstrategy.so")) {
 		printf("no strategy .so found, using built-in round-robin\n");
-		load_fallback_slot(&slots[0]);
+		load_fallback_slot(&strategy_table.slots[0]);
 	}
 
-	active_index.store(0, std::memory_order_relaxed);
+	strategy_table.active_index.store(0, std::memory_order_relaxed);
 
 	unsigned lcore_id;
 	unsigned manager_lcore = RTE_MAX_LCORE;

--- a/src/strategy_loader.cpp
+++ b/src/strategy_loader.cpp
@@ -23,8 +23,7 @@ extern "C" {
 extern struct alb_config config;
 extern uint16_t listen_port;
 
-StrategySlot slots[2];
-std::atomic<int> active_index{0};
+HotSwapTable<StrategySlotData> strategy_table;
 std::atomic<bool> running{true};
 ServerState server_states[ALB_MAX_BACKENDS];
 int num_servers;
@@ -47,6 +46,8 @@ class RoundRobinStrategy : public Strategy
 	}
 };
 
+static StrategySlotData fallback_data;
+
 static Strategy *rr_create(ServerState *servers, int count)
 {
 	return new RoundRobinStrategy(servers, count);
@@ -59,9 +60,10 @@ static void rr_destroy(Strategy *s)
 
 void load_fallback_slot(StrategySlot *slot)
 {
+	fallback_data.create = rr_create;
+	fallback_data.destroy = rr_destroy;
+	slot->data = &fallback_data;
 	slot->dl_handle = nullptr;
-	slot->create = rr_create;
-	slot->destroy = rr_destroy;
 	slot->in_flight.store(0, std::memory_order_relaxed);
 }
 
@@ -83,31 +85,36 @@ bool load_into_slot(StrategySlot *slot, const char *path)
 		return false;
 	}
 
+	static StrategySlotData loaded_data[2];
+	size_t idx = &strategy_table.slots[0] == slot ? 0 : 1;
+	loaded_data[idx].create = cr;
+	loaded_data[idx].destroy = de;
+
+	slot->data = &loaded_data[idx];
 	slot->dl_handle = h;
-	slot->create = cr;
-	slot->destroy = de;
 	slot->in_flight.store(0, std::memory_order_relaxed);
 	return true;
 }
 
 int worker_main(__rte_unused void *arg)
 {
-	int my_index = -1;
+	size_t my_index = SIZE_MAX;
 	Strategy *strat = nullptr;
 	uint32_t pkt_seq = 0;
 
 	while (running.load(std::memory_order_relaxed)) {
-		int idx = active_index.load(std::memory_order_acquire);
+		size_t idx =
+		    strategy_table.active_index.load(std::memory_order_acquire);
 
 		if (idx != my_index) {
-			if (strat && my_index >= 0) {
-				slots[my_index].destroy(strat);
-				slots[my_index].in_flight.fetch_sub(
-				    1, std::memory_order_release);
+			if (strat && my_index != SIZE_MAX) {
+				strategy_table.slots[my_index].data->destroy(
+				    strat);
+				strategy_table.slots[my_index].release();
 			}
-			slots[idx].in_flight.fetch_add(
-			    1, std::memory_order_acq_rel);
-			strat = slots[idx].create(server_states, num_servers);
+			strategy_table.slots[idx].acquire();
+			strat = strategy_table.slots[idx].data->create(
+			    server_states, num_servers);
 			my_index = idx;
 		}
 
@@ -184,10 +191,9 @@ int worker_main(__rte_unused void *arg)
 		}
 	}
 
-	if (strat && my_index >= 0) {
-		slots[my_index].destroy(strat);
-		slots[my_index].in_flight.fetch_sub(1,
-						    std::memory_order_release);
+	if (strat && my_index != SIZE_MAX) {
+		strategy_table.slots[my_index].data->destroy(strat);
+		strategy_table.slots[my_index].release();
 	}
 
 	return 0;
@@ -221,22 +227,20 @@ int manager_main(__rte_unused void *arg)
 
 		printf("new strategy detected, reloading...\n");
 
-		int old_idx = active_index.load(std::memory_order_acquire);
-		int new_idx = old_idx ^ 1;
+		StrategySlot &new_slot = strategy_table.inactive();
 
-		if (!load_into_slot(&slots[new_idx],
-				    "./strategies/libstrategy.so"))
+		if (!load_into_slot(&new_slot, "./strategies/libstrategy.so"))
 			continue;
 
-		active_index.store(new_idx, std::memory_order_release);
+		StrategySlot &old_slot = strategy_table.active();
+		strategy_table.swap();
 
-		while (slots[old_idx].in_flight.load(
-			   std::memory_order_acquire) > 0)
+		while (!old_slot.idle())
 			rte_pause();
 
-		if (slots[old_idx].dl_handle)
-			dlclose(slots[old_idx].dl_handle);
-		slots[old_idx].dl_handle = nullptr;
+		if (old_slot.dl_handle)
+			dlclose(old_slot.dl_handle);
+		old_slot.dl_handle = nullptr;
 
 		printf("reload complete\n");
 	}

--- a/src/strategy_loader.hpp
+++ b/src/strategy_loader.hpp
@@ -4,18 +4,18 @@
 #include <cstdint>
 
 #include "strategy.hpp"
+#include "table.hpp"
 
 #define BURST_SIZE 32
 
-struct StrategySlot {
-	void *dl_handle;
+struct StrategySlotData {
 	Strategy *(*create)(ServerState *, int);
 	void (*destroy)(Strategy *);
-	std::atomic<int32_t> in_flight{0};
 };
 
-extern StrategySlot slots[2];
-extern std::atomic<int> active_index;
+using StrategySlot = Slot<StrategySlotData>;
+
+extern HotSwapTable<StrategySlotData> strategy_table;
 extern std::atomic<bool> running;
 extern ServerState server_states[];
 extern int num_servers;


### PR DESCRIPTION
moved the hot-swap slot and table logic into reusable templates into version table package. strategy loader now uses these shared building blocks instead of its own duplicate implementation